### PR TITLE
🔧 Fix janalytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Bare bones analytics for Journaly.
 Ensure that `DATABASE_URL` is defined and points to the DB instance you want analytics for (that probably means prod)
 
 ```
-pip install -r requirements.py
+pip install -r requirements.txt
 jupyter notebook
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyterlab==2.2.9
-psycopg2-binary==2.8.6
-matplotlib==3.3.3
-nbconvert==6.0.7
+jupyterlab==3.5.3
+psycopg2-binary==2.9.5
+matplotlib==3.6.3
+nbconvert==7.2.9


### PR DESCRIPTION
### Description

* fixes #4 

Janalytics reports have been down for quite a few months, potentially around 6 months or so.
It looks like this is a dependency version issue, looking at the stack trace where the error was throwing in the CircleCI workflow:
```
#!/bin/bash -eo pipefail
jupyter nbconvert "Activity Report.ipynb" --execute --to html --output /tmp/activity-report.html
Traceback (most recent call last):
  File "/home/circleci/.local/bin/jupyter-nbconvert", line 5, in <module>
    from nbconvert.nbconvertapp import main
  File "/home/circleci/.local/lib/python3.10/site-packages/nbconvert/__init__.py", line 4, in <module>
    from .exporters import *
  File "/home/circleci/.local/lib/python3.10/site-packages/nbconvert/exporters/__init__.py", line 3, in <module>
    from .html import HTMLExporter
  File "/home/circleci/.local/lib/python3.10/site-packages/nbconvert/exporters/html.py", line 14, in <module>
    from jinja2 import contextfilter
ImportError: cannot import name 'contextfilter' from 'jinja2' (/home/circleci/.local/lib/python3.10/site-packages/jinja2/__init__.py)

Exited with code exit status 1
CircleCI received exit code 1
```

Looking around it appeared this was an issue with the `nbconvert` package that was fixed, but I decided to go ahead an try updating all of the packages to latest since we just have a small handful and everything is working beautifully again! We even just got our first successful report sent over to Slack before I could finish this PR description 🤣

Woohoo!